### PR TITLE
[nightshift] changelog-synth: add CHANGELOG.md from git history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to squircle will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## April 2026
+
+### Added
+
+- Add gif export and cover crop controls (9007191)
+- Add files via upload (3fcc12d)
+- Refresh readme and polish landing details (41c9632)
+- Publish squircle app (c87a67f)
+
+### Changed
+
+- Update README.md (674fba0)
+- Update README.md (6a0a1ad)
+- Update README.md (69892c3)
+- Finalize publish metadata (d881dfc)
+- Update README.md (25d277a)
+- Initial commit from Create Next App (b537543)
+
+### Fixed
+
+- Reduce background and editor render overhead (368ba55)
+- Update export naming and crop slider layout (a90510a)
+- Deband dark gradient png exports (fe9972b)
+- Add app icons and correct readme hero (2a5789c)
+
+### Removed
+
+- Delete .github/assets/squircle-showcase.mp4 (e644786)
+- Delete AGENTS.md (0395a1b)
+
+### Documentation
+
+- Update deployment access note (5ec720f)
+- Clarify vercel deployment access (0065a25)
+


### PR DESCRIPTION
Automated by **Nightshift v3** (GLM 5.1).

**Task:** Changelog Synthesizer
**Category:** pr

Synthesizes a `CHANGELOG.md` from git commit history, organized by month and category (Added, Fixed, Changed, etc.) following [Keep a Changelog](https://keepachangelog.com/) format.

Merge if useful, close if not.