### PR TITLE
[nightshift] release-notes: add CHANGELOG.md for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Initial public release of squircle — a local-first image corner tool.
+- True squircle corner profile (superellipse) with adjustable smoothness.
+- Rounded rectangle mode as a fallback profile.
+- Batch processing — drop multiple images and export them all at once.
+- GIF export with animated corner rounding.
+- Cover crop controls for framing before export.
+- Upload progress indicator for GIF processing.
+- Adjustable shadow, outline, and background controls.
+- Transparent PNG export with proper dark gradient debanding.
+- Dark mode UI built with Next.js 16, Tailwind CSS, and Radix primitives.
+- Everything runs client-side — no images leave the browser.
+
+### Fixed
+
+- Reduced background and editor render overhead for smoother interaction.
+- Corrected export file naming and crop slider layout.
+- Fixed dark gradient banding in PNG exports.
+- Added app icons and corrected README hero assets.
+
+### Changed
+
+- Refreshed README with polished landing details and deployment notes.
+- Updated deployment access documentation for Vercel.


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** Release Note Drafter
**Category:** PR
**Changes:** Adds a `CHANGELOG.md` file documenting all notable changes since the initial commit. Covers features (squircle profiles, batch processing, GIF export, crop controls, shadow/outline controls), fixes (render overhead, export naming, gradient banding, app icons), and documentation updates.

Merge if useful, close if not.