### PR TITLE
fix: address 5 edge cases in image/GIF pipeline

### DIFF
--- a/components/editor/index.tsx
+++ b/components/editor/index.tsx
@@ -95,7 +95,14 @@ function getExportHostSuffix() {
     return "";
   }
 
-  const sanitizedHostname = window.location.hostname
+  const hostname = window.location.hostname;
+
+  // Skip suffix for IP addresses to avoid cluttered filenames like "export-image_127-0-0-1.png"
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
+    return "";
+  }
+
+  const sanitizedHostname = hostname
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9-]+/g, "-")
@@ -185,7 +192,7 @@ function downloadBlob(blob: Blob, fileName: string) {
   document.body.appendChild(anchor);
   anchor.click();
   document.body.removeChild(anchor);
-  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 function waitForNextPaint() {
@@ -708,28 +715,46 @@ export function SquircleEditor() {
 
     const JSZip = (await import("jszip")).default;
     const zip = new JSZip();
+    const failedItems: string[] = [];
 
     for (let index = 0; index < mediaItems.length; index += 1) {
       const item = mediaItems[index];
 
-      if (item.kind === "gif") {
-        const blob = await renderGifItemToBlob(item);
+      try {
+        if (item.kind === "gif") {
+          const blob = await renderGifItemToBlob(item);
+          zip.file(
+            getExportFileName(getFileStem(item.file.name), "gif", index),
+            await blob.arrayBuffer(),
+          );
+          continue;
+        }
+
+        const blob = await renderStillItemToBlob(item);
         zip.file(
-          getExportFileName(getFileStem(item.file.name), "gif", index),
+          getExportFileName(getFileStem(item.file.name), "png", index),
           await blob.arrayBuffer(),
         );
-        continue;
+      } catch {
+        failedItems.push(item.file.name);
+        logClientError("Batch export failed for item", item.id);
       }
+    }
 
-      const blob = await renderStillItemToBlob(item);
-      zip.file(
-        getExportFileName(getFileStem(item.file.name), "png", index),
-        await blob.arrayBuffer(),
+    const totalSuccessful = mediaItems.length - failedItems.length;
+
+    if (failedItems.length > 0) {
+      setUploadError(
+        `Couldn't export ${failedItems.length} item${failedItems.length > 1 ? "s" : ""}: ${failedItems.join(", ")}`,
       );
     }
 
+    if (totalSuccessful === 0) {
+      return;
+    }
+
     const content = await zip.generateAsync({ type: "blob" });
-    downloadBlob(content, getExportArchiveName(mediaItems.length));
+    downloadBlob(content, getExportArchiveName(totalSuccessful));
   }, [mediaItems, renderGifItemToBlob, renderStillItemToBlob]);
 
   const removeMediaItem = useCallback((id: string, event: React.MouseEvent) => {
@@ -761,6 +786,7 @@ export function SquircleEditor() {
       return [];
     });
     setActiveMediaId(null);
+    setActiveGifFrameIndex(0);
   }, []);
 
   const handlePreviewPointerDown = useCallback((event: React.PointerEvent<HTMLCanvasElement>) => {

--- a/lib/gif.ts
+++ b/lib/gif.ts
@@ -122,7 +122,7 @@ export function composeGifFrames(
     applyPatch(workingPixels, width, height, frame);
 
     const composedFrame = {
-      delay: frame.delay,
+      delay: Math.max(20, frame.delay),
       pixels: new Uint8ClampedArray(workingPixels),
     };
 


### PR DESCRIPTION
## Summary

Fixes 5 of the 12 edge cases identified in #39 (nightshift/edge-case-enum analysis):

1. **GIF frame delay clamping** (`lib/gif.ts`) — Clamp `frame.delay` to minimum 20ms in `composeGifFrames` to prevent rapid frame cycling on GIFs with delay=0
2. **Batch export error isolation** (`components/editor/index.tsx`) — Wrap each item's render in try/catch inside the batch export loop; skip failed items and report them via `setUploadError`
3. **Blob URL cleanup timeout** (`components/editor/index.tsx`) — Increase `setTimeout` from 0ms to 1000ms so the browser finishes initiating downloads before revoking the URL
4. **IP address in export filenames** (`components/editor/index.tsx`) — Skip hostname suffix when `window.location.hostname` is an IP address (avoids `export-image_127-0-0-1.png`)
5. **Stale GIF frame index after clear** (`components/editor/index.tsx`) — Add `setActiveGifFrameIndex(0)` to `clearAll` to reset stale state

### Skipped (informational only)

- GIF disposal type 0/1 distinction — current behavior matches most GIF decoders
- SVG zero-dimension error message — UX copy only
- `normalizeHexColor` casing — not a bug
- `hexToRgba` silent NaN fallback — no production attack surface
- `MAX_UPLOAD_FILES` drag bypass — needs state refactor
- Squircle vs superellipse — docs only
- `getDeterministicNoise` overflow — 8192px cap makes it theoretical

Fixes #39